### PR TITLE
using fewer metadata fields

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,5 @@
 FROM cs50/server
 EXPOSE 8080
+
+RUN npm i -g n
+RUN n 6.9.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,10 @@ services:
   web:
     build: .
     container_name: video50_web
+    command: [ "npm", "run", "dev" ]
     ports:
-      - "8080:8080"
+    - "3000:3000"
     tty: true
     volumes:
-      - .:/var/www
+    - .:/var/www
 version: "2"

--- a/src/helpers/cdn.js
+++ b/src/helpers/cdn.js
@@ -9,62 +9,73 @@ const timeToSeconds = time => {
   return h + m + s;
 };
 
-const srtToJson = src => fetch(src)
-  .then(data => data.text())
-  .then(text => text.replace(/\n\n\n/g, '\n\n'))
-  .then(text => text ? text.split('\n\n') : [])
-  .then(arry => arry.map(caption => caption.split('\n')))
-  .then(arry => arry.filter(caption => caption[1] !== undefined))
-  .then(arry => arry.map(caption => ({
-    type: 'caption',
-    id: caption[0],
-    start: timeToSeconds(caption[1].split(' --> ')[0].replace(',', '.')),
-    end: timeToSeconds(caption[1].split(' --> ')[1].replace(',', '.')),
-    title: caption.slice(2)
-          .join(' ')
-          .replace('>> ', '')
-          .replace('-', '') || '[NO SPEECH]',
-  })))
+async function fetchAndParseVTT(url, ev, mapCallback=((l)=>{})) {
+  const res = await fetch(url);
+  if (res.status !== 200) {
+    return [];
+  }
 
-const chapters = obj => obj ? fetch(obj.src)
-  .then(data => data.text())
-  .then(text => text ? text.trim().replace('WEBVTT\n\n', '').split('\n\n') : [])
-  .then(arry => arry.map(chapter => chapter.split('\n')))
-  .then(arry =>
-    arry.map(chapter => !chapter[0].match(' --> ')
-      ? ({
-        type: 'chapter',
-        id: chapter[0],
-        start: timeToSeconds(chapter[1].split(' --> ')[0]),
-        end: timeToSeconds(chapter[1].split(' --> ')[1]),
-        title: chapter[2],
-      })
-      : ({
+  const items = (await res.text())
+    .replace('WEBVTT\n\n', '')
+    .split('\n\n')
+    .map(i => i.split('\n'))
+    .map(l => mapCallback(l));
+
+  if (ev) {
+    publish(ev, [items]);
+  }
+
+  return items;
+}
+
+export const chapters = (url) => {
+  return fetchAndParseVTT(url, 'chapters:loaded', (chapter) => {
+    if (chapter[0].match(' --> ')) {
+      return {
         type: 'chapter',
         start: timeToSeconds(chapter[0].split(' --> ')[0]),
         end: timeToSeconds(chapter[0].split(' --> ')[1]),
         title: chapter[1],
-      })
-    )
-  )
-  .then(chapters => {
-    publish('chapters:loaded', [chapters])
-    return chapters;
-  }) : [];
+      };
+    }
 
-export const captions = obj => obj ?
-  srtToJson(obj.src)
-  .then(captions => {
-    publish('captions:loaded', [captions])
-    return captions;
-  }) : [];
+    return {
+      type: 'chapter',
+      id: chapter[0],
+      start: timeToSeconds(chapter[1].split(' --> ')[0]),
+      end: timeToSeconds(chapter[1].split(' --> ')[1]),
+      title: chapter[2],
+    };
+  })
+};
 
-export const expCaptions = obj => obj ?
-  srtToJson(obj.src)
-  .then(captions => {
-    publish('exp:captions:loaded', [captions])
-    return captions;
-  }) : [];
+export const captions = async (url, ev='captions:loaded') => {
+  const res = await fetch(url);
+  if (res.status !== 200) {
+    return [];
+  }
+
+  const captions_ = (await res.text())
+    .replace(/\n\n\n/g, '\n\n')
+    .split('\n\n')
+    .map(caption => caption.split('\n'))
+    .filter(caption => caption[1] !== undefined)
+    .map(caption => ({
+      type: 'caption',
+      id: caption[0],
+      start: timeToSeconds(caption[1].split(' --> ')[0].replace(',', '.')),
+      end: timeToSeconds(caption[1].split(' --> ')[1].replace(',', '.')),
+      title: caption.slice(2)
+            .join(' ')
+            .replace('>> ', '')
+            .replace('-', '') || '[NO SPEECH]',
+    }));
+
+  publish(ev, [captions_]);
+  return captions_;
+}
+
+const expCaptions = (url) => captions(url, 'exp:captions:loaded');
 
 // Extract CDN path from widow url or default
 export const cdnEpisodefromUrl = () =>
@@ -123,35 +134,37 @@ export const videoScreenshotFromUrl = (url, time) =>
     });
   });
 
-export const markers = (chaptersUrl, captionsUrl) =>
-  Promise.all([chapters(chaptersUrl), captions(captionsUrl)])
-  .then(values => [].concat(values[0], values[1]))
-  .then(items => items.sort((a, b) => {
-    if (a.start > b.start) { return 1; }
-    if (a.start < b.start) { return -1; }
-    return 0;
-  }))
-  .then(markers => markers.length > 0 ?
-    publish('markers:fetched', [markers]) : null
-  );
+export const markers = (items) => {
+  if (items.length) {
+    items.sort((a, b) => {
+      if (a.start > b.start) {
+        return 1;
+      }
+      else if (a.start < b.start) {
+        return -1;
+      }
 
-export const thumbs = obj => obj ? fetch(obj.src)
-  .then(data => data.text())
-  .then(text => text.replace('WEBVTT\n\n', '').split('\n\n'))
-  .then(arry => arry.map(thumb => thumb.split('\n')))
-  .then(arry => arry.map(thumb => ({
+      return 0;
+    });
+
+    publish('markers:fetched', [items]);
+    return items;
+  }
+
+  return null;
+}
+
+export const thumbs = (url) => {
+  return fetchAndParseVTT(url, 'thumbnails:fetched', (t) => ({
     type: 'thumb',
-    start: timeToSeconds(thumb[0].split(' --> ')[0]),
-    end: timeToSeconds(thumb[0].split(' --> ')[1]),
-    url: thumb[1],
-  })))
-  .then(data => publish('thumbnails:fetched', [data])) : [];
+    start: timeToSeconds(t[0].split(' --> ')[0]),
+    end: timeToSeconds(t[0].split(' --> ')[1]),
+    url: t[1],
+  }));
+}
 
-export const explained = src => src ? fetch(src)
-  .then(data => data.text())
-  .then(text => text ? text.replace('WEBVTT\n\n', '').split('\n\n') : [])
-  .then(arry => arry.map(explained => explained.split('\n')))
-  .then(arry => arry.map(explained => ({
+export const explained = (url) => {
+  return fetchAndParseVTT(url, 'explained:fetched', (l) => ({
     title: explained[2],
     youtube: {
       main: explained[3],
@@ -159,5 +172,5 @@ export const explained = src => src ? fetch(src)
     captions: explained[4],
     start: timeToSeconds(explained[1].split(' --> ')[0]),
     end: timeToSeconds(explained[1].split(' --> ')[1])
-   })))
-  .then(data => publish('explained:fetched', [data])) : [];
+  }));
+}

--- a/src/helpers/document.js
+++ b/src/helpers/document.js
@@ -40,7 +40,7 @@ export default () => {
       const elem = document.elementFromPoint(e.clientX, e.clientY);
       showPlayerChrome();
       clearTimeout(timer);
-      if (elem.tagName === 'VIDEO-MAIN' || elem.tagName === 'VIDEO-ALT') {
+      if (elem && ['VIDEO-MAIN', 'VIDEO-ALT'].indexOf(elem.tagName) > -1) {
         timer = setTimeout(hidePlayerChrome, 3000);
       }
     };

--- a/src/index.js
+++ b/src/index.js
@@ -174,7 +174,7 @@ module.exports = (() => {
       // Try "lecture0.vtt" or fallback to "week0.vtt"
       thumbs(`${prefix}/${lectureBasename}.vtt`).then((data) => {
         if (data && !data.length) {
-            thumbs(`${prefix}/${lectureBasename.replace('lecture', 'week')}.vtt`);
+          thumbs(`${prefix}/${lectureBasename.replace('lecture', 'week')}.vtt`);
         }
       })
     });

--- a/src/index.js
+++ b/src/index.js
@@ -92,14 +92,7 @@ module.exports = (() => {
     const prefix = `${cdnUrl}${id}`
 
     // Fetch episode data from CDN based on URL
-    fetch(`${prefix}/metadata.json`)
-    .then((res) => {
-        if (res.status !== 200) {
-          return fetch(`${prefix}/index.json`);
-        }
-
-        return res;
-    })
+    fetch(`${prefix}/index.json`)
     .then(data => data.json())
     .then(ep => {
       const mainVideoId = ep.youtube && ep.youtube.main;


### PR DESCRIPTION
This PR allows video50 to read captions, chapters, thumbnails, etc without necessarily having them in an `index.json` file so that we don't need to update `index.json` every time something changes in CDN.